### PR TITLE
XFail search_for_valid_signature, until we fix the test to search for two weeks' worth

### DIFF
--- a/test_search.py
+++ b/test_search.py
@@ -49,6 +49,7 @@ class TestSearchForIdOrSignature:
         results = csp.search_for_crash("this won't exist")
         Assert.true(results.can_find_text('No results were found.'))
 
+    @xfail(reason="Temporarily xfailing until https://www.pivotaltracker.com/story/show/19070579 is written, to cover 2 weeks' worth of data")
     def test_that_search_for_valid_signature(self, mozwebqa):
         '''
             This is a test for


### PR DESCRIPTION
XFail search_for_valid_signature, since on staging, some signatures we pick only have 1 weeks' worth of data...

Matt, not sure if you want this, or if you'd prefer to keep failing
until we've actually rewritten that test.

I did enter https://www.pivotaltracker.com/story/show/19070579 to cover this, though!
