### PR TITLE
Bug 607875 - Filtering for a past date returns results

### DIFF
--- a/crash_stats_page.py
+++ b/crash_stats_page.py
@@ -456,6 +456,7 @@ class CrashStatsPerActiveDailyUser(CrashStatsBasePage):
     _date_start_locator = 'css=.daily_search_body .date[name="date_start"]'
     _generate_button_locator = "id=daily_search_version_form_submit"
     _table_locator = "id=crash_data"
+    _row_table_locator = "css=#crash_data > tbody > tr"
 
     def __init__(self, testsetup):
         '''
@@ -468,8 +469,8 @@ class CrashStatsPerActiveDailyUser(CrashStatsBasePage):
     def product_select(self):
         return self.sel.get_selected_value(self._product_select)
 
-    def input_date_start(self, date_var):
-        return self.sel.type(self._date_start_locator, date_var)
+    def type_start_date(self, date):
+        self.sel.type(self._date_start_locator, date)
 
     def click_generate_button(self):
         self.sel.click(self._generate_button_locator)
@@ -478,6 +479,14 @@ class CrashStatsPerActiveDailyUser(CrashStatsBasePage):
     @property
     def is_table_visible(self):
         return self.sel.is_visible(self._table_locator)
+
+    @property
+    def table_row_count(self):
+        return self.sel.get_css_count(self._row_table_locator)
+
+    @property
+    def last_row_date_value(self):
+        return self.selenium.get_text('css=#crash_data > tbody > tr:nth(%s) > td:nth(0)' % (int(self.table_row_count) - 2))
 
 
 class CrashStatsTopCrashers(CrashStatsBasePage):

--- a/test_crash_reports.py
+++ b/test_crash_reports.py
@@ -320,12 +320,13 @@ class TestCrashReports:
         """
         https://www.pivotaltracker.com/story/show/17141439
         """
-        self.selenium = mozwebqa.selenium
         csp = CrashStatsHomePage(mozwebqa)
         crash_per_user = csp.select_report('Crashes per User')
-        crash_per_user.input_date_start('1990-01-01')
+        crash_per_user.type_start_date('1995-01-01')
         crash_per_user.click_generate_button()
         Assert.true(crash_per_user.is_table_visible)
+        crash_per_user.table_row_count
+        Assert.equal('1995-01-01', crash_per_user.last_row_date_value)
 
     def test_that_top_crashers_reports_links_work_for_firefox(self, mozwebqa):
         """


### PR DESCRIPTION
Bug 607875 - Filtering the list for a date range with start date being in the very past should return results.
Pivotal id: https://www.pivotaltracker.com/story/show/17141439
