### PR TITLE
Expanded Top Crashers report tests to cover Browser and Plugin filters.

### DIFF
--- a/crash_stats_page.py
+++ b/crash_stats_page.py
@@ -457,6 +457,8 @@ class CrashStatsTopCrashers(CrashStatsBasePage):
     _product_version_header = 'css=h2 > span.current-version'
 
     _filter_all = "link=All"
+    _filter_browser = "link=Browser"
+    _filter_plugin = "link=Plugin"
 
     _result_rows = "css=table#signatureList > tbody > tr"
 
@@ -477,8 +479,16 @@ class CrashStatsTopCrashers(CrashStatsBasePage):
         return self.sel.get_css_count(self._result_rows)
 
     def click_filter_all(self):
-        self.click(self._filter_all, True)
+        self.sel.click(self._filter_all);
+        self.sel.wait_for_page_to_load(self.timeout)
 
+    def click_filter_browser(self):
+        self.sel.click(self._filter_browser)
+        self.sel.wait_for_page_to_load(self.timeout)
+
+    def click_filter_plugin(self):
+        self.sel.click(self._filter_plugin)
+        self.sel.wait_for_page_to_load(self.timeout)
 
 class CrashStatsTopCrashersByUrl(CrashStatsBasePage):
 

--- a/test_crash_reports.py
+++ b/test_crash_reports.py
@@ -265,7 +265,7 @@ class TestCrashReports:
             #Bug 611694 - Disabled till bug fixed
             #Assert.true(cstc.product_version_header in details['versions'])
 
-    def test_that_top_crasher_filters_return_results(self, mozwebqa):
+    def test_that_top_crasher_filter_all_return_results(self, mozwebqa):
         # https://bugzilla.mozilla.org/show_bug.cgi?id=678906
         self.selenium = mozwebqa.selenium
         csp = CrashStatsHomePage(mozwebqa)
@@ -275,6 +275,32 @@ class TestCrashReports:
             Assert.equal(details['product'], cstc.product_header)
 
         cstc.click_filter_all()
+        results = cstc.count_results
+        Assert.true(results > 0, "%s results found, expected >0" % results)
+
+    def test_that_top_crasher_filter_browser_return_results(self, mozwebqa):
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=678906
+        self.selenium = mozwebqa.selenium
+        csp = CrashStatsHomePage(mozwebqa)
+        details = csp.current_details
+        cstc = csp.select_report('Top Crashers')
+        if csp.results_found:
+            Assert.equal(details['product'], cstc.product_header)
+
+        cstc.click_filter_browser()
+        results = cstc.count_results
+        Assert.true(results > 0, "%s results found, expected >0" % results)
+
+    def test_that_top_crasher_filter_plugin_return_results(self, mozwebqa):
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=678906
+        self.selenium = mozwebqa.selenium
+        csp = CrashStatsHomePage(mozwebqa)
+        details = csp.current_details
+        cstc = csp.select_report('Top Crashers')
+        if csp.results_found:
+            Assert.equal(details['product'], cstc.product_header)
+
+        cstc.click_filter_plugin()
         results = cstc.count_results
         Assert.true(results > 0, "%s results found, expected >0" % results)
 


### PR DESCRIPTION
Enhanced coverage for bug #678906 as the filters weren't properly covered before.
