### PR TITLE
(Untested) s/coloumn/column, in crash_stats_page.py

### DIFF
--- a/pages/crash_stats_page.py
+++ b/pages/crash_stats_page.py
@@ -315,9 +315,9 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
 
     _radio_items_locator = 'css=.radio-item > label > input'
 
-    _data_table_signature_coloumn_locator = 'css=table#signatureList > tbody > tr > td:nth-child(2)'
-    _data_table_signature_browser_icon_locator = _data_table_signature_coloumn_locator + ' > div > img.browser'
-    _data_table_signature_plugin_icon_locator = _data_table_signature_coloumn_locator + ' > div > img.plugin'
+    _data_table_signature_column_locator = 'css=table#signatureList > tbody > tr > td:nth-child(2)'
+    _data_table_signature_browser_icon_locator = _data_table_signature_column_locator + ' > div > img.browser'
+    _data_table_signature_plugin_icon_locator = _data_table_signature_column_locator + ' > div > img.plugin'
     _next_locator = 'css=.pagination>a:contains("Next") '
     _plugin_filename_header_locator = "css=table#signatureList > thead th:contains('Plugin Filename')"
 


### PR DESCRIPTION
Sorry, still don't have the ability to test this, but a quick grep shows it should be OK; would appreciate it if someone could test and merge:

host-7-18:Socorro-Tests moco$ grep "colou" -r .
./.git/COMMIT_EDITMSG:s/coloumn/column, in crash_stats_page.py
./.git/logs/HEAD:dd756f05473314c1e3532decd45995c439958295 cd373f6fdf147ffd6afda88b99416370ffd2e478 Stephen Donner stephen.donner@gmail.com 1326932085 -0800   commit: s/coloumn/column, in crash_stats_page.py
./.git/logs/refs/heads/master:dd756f05473314c1e3532decd45995c439958295 cd373f6fdf147ffd6afda88b99416370ffd2e478 Stephen Donner stephen.donner@gmail.com 1326932085 -0800  commit: s/coloumn/column, in crash_stats_page.py
