### PR TITLE
Remove url messages

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -18,7 +18,7 @@ class TestCrashReports:
         csp = CrashStatsHomePage(mozwebqa)
         Assert.contains('Firefox', csp.page_title)
         crash_adu = csp.header.select_report('Crashes per User')
-        Assert.equal(csp.header.current_product, crash_adu.product_select, csp.get_url_current_page())
+        Assert.equal(csp.header.current_product, crash_adu.product_select)
 
     def test_that_reports_form_has_same_product_for_thunderbird(self, mozwebqa):
         self._verify_reports_form_have_same_product(mozwebqa, 'Thunderbird')
@@ -37,7 +37,7 @@ class TestCrashReports:
         product = csp.header.current_product
         cstc = csp.header.select_report('Top Crashers')
         if csp.results_found:
-            Assert.equal(product, cstc.product_header, cstc.get_url_current_page())
+            Assert.equal(product, cstc.product_header)
             #Bug 611694 - Disabled till bug fixed
             #Assert.true(cstc.product_version_header in details['versions'])
 
@@ -59,7 +59,7 @@ class TestCrashReports:
         product = csp.header.current_product
         cstc = csp.header.select_report('Top Crashers')
         if csp.results_found:
-            Assert.equal(product, cstc.product_header, csp.get_url_current_page())
+            Assert.equal(product, cstc.product_header)
 
         cstc.click_filter_by('All')
         Assert.greater(cstc.count_results, 0)
@@ -75,7 +75,7 @@ class TestCrashReports:
 
         #test external link works
         nightly_builds_page.click_link_to_ftp()
-        Assert.equal(website_link, nightly_builds_page.get_url_current_page(), nightly_builds_page.get_url_current_page())
+        Assert.equal(website_link, nightly_builds_page.get_url_current_page())
 
     def test_that_products_page_links_work(self, mozwebqa):
         products_page = ProductsLinksPage(mozwebqa)
@@ -85,7 +85,7 @@ class TestCrashReports:
 
         for product in products:
             csp = products_page.click_product(product)
-            Assert.true(csp.get_url_current_page().endswith(product), csp.get_url_current_page())
+            Assert.true(csp.get_url_current_page().endswith(product))
             Assert.contains(product, csp.page_heading)
             products_page = ProductsLinksPage(mozwebqa)
 
@@ -121,7 +121,7 @@ class TestCrashReports:
             if csp.results_found:
                 csp.header.select_version(version)
                 cstc = csp.header.select_report('Top Changers')
-                Assert.true(cstc.is_top_changers_highlighted, cstc.get_url_current_page())
+                Assert.true(cstc.is_top_changers_highlighted)
 
     @pytest.mark.xfail(reason="Bug 721928 - We shouldn't let the user query /daily for dates past for which we don't have data")
     def test_that_filtering_for_a_past_date_returns_results(self, mozwebqa):
@@ -133,7 +133,7 @@ class TestCrashReports:
         crash_per_user.type_start_date('1995-01-01')
         crash_per_user.click_generate_button()
         Assert.true(crash_per_user.is_table_visible)
-        Assert.equal('1995-01-01', crash_per_user.last_row_date_value, crash_per_user.get_url_current_page())
+        Assert.equal('1995-01-01', crash_per_user.last_row_date_value)
 
     def test_that_top_crashers_reports_links_work_for_firefox(self, mozwebqa):
         """
@@ -184,7 +184,7 @@ class TestCrashReports:
         top_crashers = csp.top_crashers
         for idx in range(len(top_crashers)):
             top_crasher_page = top_crashers[idx].click_top_crasher()
-            Assert.true(top_crasher_page.table_results_found, top_crasher_page.get_url_current_page())
+            Assert.true(top_crasher_page.table_results_found)
             CrashStatsHomePage(mozwebqa)
             top_crashers = csp.top_crashers
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -17,14 +17,14 @@ class TestLayout:
 
         product_list = ['Firefox', 'Thunderbird', 'Camino', 'SeaMonkey', 'Fennec', 'FennecAndroid']
         products = [product.text for product in  csp.header.product_list]
-        Assert.equal(product_list, products, csp.get_url_current_page())
+        Assert.equal(product_list, products)
 
     @xfail(reason='Bug 687841 - Versions in Navigation Bar appear in wrong order')
     def test_that_product_versions_are_ordered_correctly(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
 
-        Assert.is_sorted_descending(csp.header.current_versions, csp.get_url_current_page())
-        Assert.is_sorted_descending(csp.header.other_versions, csp.get_url_current_page())
+        Assert.is_sorted_descending(csp.header.current_versions)
+        Assert.is_sorted_descending(csp.header.other_versions)
 
     def test_that_topcrasher_is_not_returning_http500(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -16,7 +16,7 @@ class TestSearchForIdOrSignature:
         csp = CrashStatsHomePage(mozwebqa)
 
         results = csp.header.search_for_crash("this won't exist")
-        Assert.false(results.results_found, results.get_url_current_page())
+        Assert.false(results.results_found)
 
     def test_that_search_for_valid_signature(self, mozwebqa):
         """.....
@@ -28,7 +28,7 @@ class TestSearchForIdOrSignature:
         signature = report_list.first_valid_signature
 
         result = csp.header.search_for_crash(signature)
-        Assert.true(result.results_found, result.get_url_current_page())
+        Assert.true(result.results_found)
 
     def test_that_advanced_search_for_firefox_can_be_filtered(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
@@ -77,7 +77,7 @@ class TestSearchForIdOrSignature:
         results_page_count = cs_advanced.first_signature_number_of_results
         cssr = cs_advanced.click_first_signature()
         cssr.click_reports()
-        Assert.equal(results_page_count, cssr.total_items_label, cssr.get_url_current_page())
+        Assert.equal(results_page_count, cssr.total_items_label)
 
     @prod
     def test_that_search_for_a_given_build_id_works(self, mozwebqa):
@@ -94,7 +94,7 @@ class TestSearchForIdOrSignature:
         if cs_advanced.results_found:
             Assert.true(cs_advanced.first_signature_number_of_results > 0)
         else:
-            Assert.equal(cs_advanced.query_results_text(1), 'No results were found.', cs_advanced.get_url_current_page())
+            Assert.equal(cs_advanced.query_results_text(1), 'No results were found.')
 
     @prod
     @xfail(reason='Disabled until bug 720037 is fixed')
@@ -114,7 +114,7 @@ class TestSearchForIdOrSignature:
             except:
                 Assert.fail('reached the last page and no data was found')
 
-        Assert.true(cs_advanced.is_browser_icon_visible, cs_advanced.get_url_current_page())
+        Assert.true(cs_advanced.is_browser_icon_visible)
 
     @prod
     def test_that_plugin_filters_result(self, mozwebqa):
@@ -132,7 +132,7 @@ class TestSearchForIdOrSignature:
         while not cs_advanced.is_plugin_icon_visible:
             cs_advanced.click_next()
 
-        Assert.true(cs_advanced.is_plugin_icon_visible, cs_advanced.get_url_current_page())
+        Assert.true(cs_advanced.is_plugin_icon_visible)
 
     @prod
     def test_that_plugin_filename_column_sorts(self, mozwebqa):
@@ -153,4 +153,4 @@ class TestSearchForIdOrSignature:
             cs_advanced.click_plugin_filename_header()
             Assert.is_sorted_descending(cs_advanced.plugin_filename_results_list())
         else:
-            Assert.equal(cs_advanced.query_results_text(1), 'No results were found.', cs_advanced.get_url_current_page())
+            Assert.equal(cs_advanced.query_results_text(1), 'No results were found.')

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -27,38 +27,38 @@ class TestSmokeTests:
         cssearch = csp.header.click_advanced_search()
         nav_product_list = csp.header.product_list
         search_product_list = cssearch.product_list
-        Assert.equal(len(nav_product_list), len(search_product_list), csp.get_url_current_page())
+        Assert.equal(len(nav_product_list), len(search_product_list))
         for i, prod_item in range(0, len(nav_product_list)):
-            Assert.equal(prod_item, search_product_list[i], csp.get_url_current_page())
+            Assert.equal(prod_item, search_product_list[i])
 
     def test_that_advanced_search_has_firefox_highlighted_in_multiselect(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         cs_advanced = csp.header.click_advanced_search()
-        Assert.equal('Firefox', cs_advanced.currently_selected_product, cs_advanced.get_url_current_page())
+        Assert.equal('Firefox', cs_advanced.currently_selected_product)
 
     def test_that_advanced_search_has_thunderbird_highlighted_in_multiselect(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product('Thunderbird')
         cs_advanced = csp.header.click_advanced_search()
-        Assert.equal('Thunderbird', cs_advanced.currently_selected_product, cs_advanced.get_url_current_page())
+        Assert.equal('Thunderbird', cs_advanced.currently_selected_product)
 
     def test_that_advanced_search_has_fennec_highlighted_in_multiselect(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product('Fennec')
         cs_advanced = csp.header.click_advanced_search()
-        Assert.equal('Fennec', cs_advanced.currently_selected_product, cs_advanced.get_url_current_page())
+        Assert.equal('Fennec', cs_advanced.currently_selected_product)
 
     def test_that_advanced_search_has_camino_highlighted_in_multiselect(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product('Camino')
         cs_advanced = csp.header.click_advanced_search()
-        Assert.equal('Camino', cs_advanced.currently_selected_product, cs_advanced.get_url_current_page())
+        Assert.equal('Camino', cs_advanced.currently_selected_product)
 
     def test_that_advanced_search_has_seamonkey_highlighted_in_multiselect(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product('SeaMonkey')
         cs_advanced = csp.header.click_advanced_search()
-        Assert.equal('SeaMonkey', cs_advanced.currently_selected_product, cs_advanced.get_url_current_page())
+        Assert.equal('SeaMonkey', cs_advanced.currently_selected_product)
 
     def test_that_advanced_search_view_signature_for_firefox_crash(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)

--- a/tests/test_specific_versions.py
+++ b/tests/test_specific_versions.py
@@ -23,5 +23,5 @@ class TestSpecificVersions:
         crash_report_page.click_reports()
 
         for report in crash_report_page.reports:
-            Assert.equal(report.product, product, crash_report_page.get_url_current_page())
+            Assert.equal(report.product, product)
             Assert.contains(report.version, str(versions[1]))


### PR DESCRIPTION
These messages are no longer required because the plugin logs the URL of the page and writes it into the HTML report.
