### PR TITLE
Updated the lowest version # to 10.0

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -220,7 +220,7 @@ class TestCrashReports:
         https://bugzilla.mozilla.org/show_bug.cgi?id=655506
         """
         csp = CrashStatsHomePage(mozwebqa)
-        csp.header.select_version('3.5.13')
+        csp.header.select_version('10.0')
         cstc = csp.header.select_report('Top Crashers')
         cstc.click_filter_days_by('14')
         Assert.not_equal('Unable to load data System error, please retry in a few minutes', cstc.page_heading)


### PR DESCRIPTION
The lowest version number for Firefox that can now be filtered on in crash-stats is 10.0 (previously it was 3.5.13). This pull updates <code>test_that_lowest_version_topcrashers_do_not_return_errors(self), mozwebqa):</code>.
