### PR TITLE
Updated version # in test to 10.0.1

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -220,7 +220,7 @@ class TestCrashReports:
         https://bugzilla.mozilla.org/show_bug.cgi?id=655506
         """
         csp = CrashStatsHomePage(mozwebqa)
-        csp.header.select_version('10.0')
+        csp.header.select_version('10.0.1')
         cstc = csp.header.select_report('Top Crashers')
         cstc.click_filter_days_by('14')
         Assert.not_equal('Unable to load data System error, please retry in a few minutes', cstc.page_heading)


### PR DESCRIPTION
A very minor change; the lowest version of Firefox in the drop down selector has been up-cycled from <code>10.0</code> to <code>10.0.1</code>.
