### PR TITLE
bumped the firefox version upwards in 2 search tests

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -121,7 +121,7 @@ class TestSearchForIdOrSignature:
         cs_advanced = csp.header.click_advanced_search()
         cs_advanced.adv_select_product('Firefox')
         cs_advanced.deselect_version()
-        cs_advanced.adv_select_version('Firefox 16.0a1')
+        cs_advanced.adv_select_version('Firefox 16.0a2')
         cs_advanced.adv_select_os('Windows')
         cs_advanced.select_report_process('Browser')
 
@@ -147,7 +147,7 @@ class TestSearchForIdOrSignature:
         cs_advanced = csp.header.click_advanced_search()
         cs_advanced.adv_select_product('Firefox')
         cs_advanced.deselect_version()
-        cs_advanced.adv_select_version('Firefox 16.0a1')
+        cs_advanced.adv_select_version('Firefox 16.0a2')
         cs_advanced.adv_select_os('Windows')
 
         cs_advanced.select_report_process('Plugins')


### PR DESCRIPTION
Preparing for a larger pull (_soon to come_) that will mitigate the need to monitor and up-cycle version numbers. - updated the Firefox version number on two search tests.
