### PR TITLE
Refactor adv search tests

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,7 +54,7 @@ class TestSearchForIdOrSignature:
         cs_advanced.set_period_value_field_input('\b3')
         cs_advanced.select_period_units('Days')
         cs_advanced.click_filter_reports()
-        Assert.contains(('product is one of %s' % product), cs_advanced.results_lead_in_text)
+        Assert.contains('product is one of %s' % product, cs_advanced.results_lead_in_text)
 
     @pytest.mark.xfail(reason='Disabled until bug 688256 is fixed')
     @pytest.mark.nondestructive


### PR DESCRIPTION
A couple things to note:
- I've parametrized the tests that simply filter on a product 
- I've updated the tests to filter on only <code>3 days</code>  instead of the default of <code>1 week</code>. This was causing a 500 error to be thrown on a Firefox test Firefox -- see <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=768260">bug 768260</a>.
- the xfail on <code>test_that_advanced_search_for_firefox_can_be_filtered</code> was technically invalid because the test had been updated to filter on <code>3 days</code> of data.
