### PR TITLE
remove xfail -- the test has been updated to be more relevant

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,7 +77,6 @@ class TestSearchForIdOrSignature:
         cs_advanced.click_filter_reports()
         Assert.contains('product is one of SeaMonkey', cs_advanced.results_lead_in_text)
 
-    @pytest.mark.xfail(reason='Disabled until bug 688256 is fixed')
     @pytest.mark.nondestructive
     def test_that_advanced_search_drilldown_results_are_correct(self, mozwebqa):
         # https://bugzilla.mozilla.org/show_bug.cgi?id=679310


### PR DESCRIPTION
The team deemed that filters that are overly broad (ie. give me crash data on every product and every release for the past 5 years) won't be supported -- currently we haven't identified a use case.
- Previously the test was updated to only query for 3 days worth of data - commit b05ac090334cc1966f15c1cd973a605f6891ea05
- I forgot to remove the xfail

This pull simply removes the xfail
