### PR TITLE
Robustify search

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -134,6 +134,8 @@ class CrashStatsBasePage(Page):
                 Type the signature or the id of a bug into the search bar and submit the form
             '''
             search_box = self.selenium.find_element(*self._find_crash_id_or_signature)
+            # explicitly only testing search and not the onfocus event which clears the 
+            # search field
             search_box.clear()
             search_box.send_keys(crash_id_or_signature)
             search_box.send_keys(Keys.RETURN)


### PR DESCRIPTION
@stephendonner discovered a curiously sporadic failure -- search tests could (and would) sporadically fail if the <code>onfocus</code> event wasn't given enough time to fire when Webdriver executed <code>send_keys(Keys.RETURN)</code>. The result was that a search would include the appended helper text, 'Find Crash ID or Signature'. 

After discussion with @Lonnen & @stephendonner we agreed the PO could exclude the onfocus event only focusing on executing and returning search results.

I've added a <code>clear()</code> to ensure the default helper text is no longer in the field before <code>send_keys(crash_id_or_signature)</code>.
