### PR TITLE
Remove valid signature distinctions

### DIFF
--- a/pages/crash_stats_top_crashers_page.py
+++ b/pages/crash_stats_top_crashers_page.py
@@ -89,16 +89,12 @@ class CrashStatsTopCrashers(CrashStatsBasePage):
     def signature_items(self):
         return [self.SignatureItem(self.testsetup, i) for i in self.selenium.find_elements(*self._signature_table_row_locator)]
 
-    @property
-    def valid_signature_items(self):
-        return [self.SignatureItem(self.testsetup, i) for i in self.selenium.find_elements(*self._signature_table_row_locator) if i.text != 'empty signature']
-
-    def click_first_valid_signature(self):
-        return self.valid_signature_items[0].click()
+    def click_first_signature(self):
+        return self.signature_items[0].click()
 
     @property
-    def first_valid_signature_title(self):
-        return self.valid_signature_items[0].title
+    def first_signature_title(self):
+        return self.signature_items[0].title
 
     class SignatureItem(Page):
         _signature_link_locator = (By.CSS_SELECTOR, 'a.signature')

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,7 +39,7 @@ class TestSearchForIdOrSignature:
         """
         csp = CrashStatsHomePage(mozwebqa)
         report_list = csp.click_first_product_top_crashers_link()
-        signature = report_list.first_valid_signature_title
+        signature = report_list.first_signature_title
 
         result = csp.header.search_for_crash(signature)
         Assert.true(result.are_results_found)
@@ -67,7 +67,7 @@ class TestSearchForIdOrSignature:
             csp.header.select_version(str(versions[1]))
 
         report_list = csp.click_first_product_top_crashers_link()
-        crash_report_page = report_list.click_first_valid_signature()
+        crash_report_page = report_list.click_first_signature()
         crash_report_page.click_reports()
 
         for report in crash_report_page.reports:


### PR DESCRIPTION
I've discovered from these bugs that the 'empty signature' behaviour in Socorro has been resolved and replaced with proper data.

We no longer need to distinguish between the two when running tests.

https://bugzilla.mozilla.org/show_bug.cgi?id=718006
https://bugzilla.mozilla.org/show_bug.cgi?id=698585
https://bugzilla.mozilla.org/show_bug.cgi?id=682883
