### PR TITLE
Set implicit wait for is visible, Add explicit ajax wait to status page ...

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -28,6 +28,7 @@ class CrashStatsBasePage(Page):
 
     def click_server_status(self):
         self.selenium.find_element(*self._server_status_locator).click()
+        self.wait_for_ajax()
         from pages.status_page import CrashStatsStatus
         return CrashStatsStatus(self.testsetup)
 

--- a/pages/page.py
+++ b/pages/page.py
@@ -52,17 +52,15 @@ class Page(object):
             self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
 
     def is_element_visible(self, parent_element, *locator):
-        self.selenium.implicitly_wait(0)
         try:
             if parent_element is not None:
-                return parent_element.find_element(*locator).is_displayed()
+                element = parent_element.find_element(*locator)
+                return element.is_displayed()
             else:
-                return self.selenium.find_element(*locator).is_displayed()
+                element = self.selenium.find_element(*locator)
+                return element.is_displayed()
         except NoSuchElementException, ElementNotVisibleException:
             return False
-        finally:
-            # set back to where you once belonged
-            self.selenium.implicitly_wait(self.testsetup.default_implicit_wait)
 
     def return_to_previous_page(self):
         self.selenium.back()


### PR DESCRIPTION
I have tried to pre-empt failures by adding an ajax explicit wait and also re-instating the implicit wait for the is_element_visible (which makes it match the equivalent method in other projects).

I've also split the find_element and is_displayed into separate lines so we can see if one step is failing.
