### PR TITLE
Refactor advanced view signature test

### DIFF
--- a/pages/advanced_search_page.py
+++ b/pages/advanced_search_page.py
@@ -73,6 +73,7 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
 
     def click_filter_reports(self):
         self.selenium.find_element(*self._filter_crash_reports_button).click()
+        self.wait_for_ajax()
 
     def click_first_signature(self):
         return self.results[0].click_signature()
@@ -106,11 +107,7 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
 
     @property
     def are_results_found(self):
-        try:
-            self.selenium.find_element(*self._table_row_locator)
-            return True
-        except NoSuchElementException:
-            return False
+        self.is_element_present(*self._table_row_locator)
 
     @property
     def no_results_text(self):

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -116,6 +116,14 @@ class CrashStatsBasePage(Page):
             select = Select(version_dropdown)
             select.select_by_visible_text(str(version))
 
+        def select_version_by_index(self, index):
+            '''
+                Select the version of the application you want to report on
+            '''
+            version_dropdown = self.selenium.find_element(*self._all_versions_locator)
+            select = Select(version_dropdown)
+            select.select_by_index(index)
+
         def select_report(self, report_name):
             '''
                 Select the report type from the drop down

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -54,15 +54,18 @@ class TestSmokeTests:
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
     def test_that_advanced_search_view_signature_for_product_crash(self, mozwebqa, product):
+        if product == 'Camino': pytest.xfail(reason='bug 775254 - No data currently available for Camino')
+
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)
+        # Pick the version by index rather than string
+        csp.header.select_version_by_index(1)
         cs_advanced = csp.header.click_advanced_search()
         cs_advanced.click_filter_reports()
 
-        if cs_advanced.are_results_found:
-            signature = cs_advanced.results[0].signature
-            cssr = cs_advanced.click_first_signature()
-            Assert.contains(signature, cssr.page_heading)
+        signature = cs_advanced.results[0].signature
+        cssr = cs_advanced.click_first_signature()
+        Assert.contains(signature, cssr.page_heading)
 
     @pytest.mark.nondestructive
     def test_that_simple_querystring_doesnt_return_500(self, mozwebqa):


### PR DESCRIPTION
Had a look at this test and noticed it was creating false positives.
Removed the `if` logic to allow the test to fail hard and properly
Filtered the results by the latest version to reduce the load time
Added an explicit wait as a precautionary measure if resultset increases in size.
