### PR TITLE
Change are_results_found to trigger implicit wait

### DIFF
--- a/pages/advanced_search_page.py
+++ b/pages/advanced_search_page.py
@@ -107,7 +107,7 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
 
     @property
     def are_results_found(self):
-        return self.is_element_present(*self._table_row_locator)
+        return len(self.results) > 0
 
     @property
     def no_results_text(self):


### PR DESCRIPTION
As above.

Previous implementation was checking the results before the results ajax had completed
