### PR TITLE
Made clicking on a random page conditional on there being a navigation div

### DIFF
--- a/pages/advanced_search_page.py
+++ b/pages/advanced_search_page.py
@@ -119,8 +119,9 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
         return self.selenium.find_element(*self._no_results_text_locator).text
 
     def go_to_random_result_page(self):
-        import random
-        random.choice(self.selenium.find_elements(*self._pagination_locator)).click()
+        if self.is_element_visible(None, *self._pagination_locator):
+            import random
+            random.choice(self.selenium.find_elements(*self._pagination_locator)).click()
 
     def click_next(self):
         self.selenium.find_element(*self._next_locator).click()


### PR DESCRIPTION
The test was failing in production as there was not more than 1 page of results and therefore no navigation div. I did notice that the test is quite slow, though, as it checks every single result on the page for the plugin icon. Might it be acceptable to check fewer than all of the results?
