### PR TITLE
Changes to speed up test_that_plugin_filters_result

### DIFF
--- a/pages/advanced_search_page.py
+++ b/pages/advanced_search_page.py
@@ -142,6 +142,9 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
             random_results.append(random.choice(results))
         return random_results
 
+    def top_results(self, count):
+        return self.results[:count]
+
     @property
     def results_table_header(self):
         return self.ResultHeader(self.testsetup)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -149,7 +149,6 @@ class TestSearchForIdOrSignature:
         cs_advanced.select_report_process('Plugins')
 
         cs_advanced.click_filter_reports()
-        cs_advanced.go_to_random_result_page()
 
         # verify the plugin icon is visible
         for result in cs_advanced.random_results(19):
@@ -157,9 +156,9 @@ class TestSearchForIdOrSignature:
 
         # verify ascending & descending sort
         cs_advanced.results_table_header.click_sort_by_plugin_filename()
-        plugin_filename_results_list = [row.plugin_filename.lower() for row in cs_advanced.results]
+        plugin_filename_results_list = [row.plugin_filename.lower() for row in cs_advanced.top_results(19)]
         Assert.is_sorted_ascending(plugin_filename_results_list)
 
         cs_advanced.results_table_header.click_sort_by_plugin_filename()
-        plugin_filename_results_list = [row.plugin_filename.lower() for row in cs_advanced.results]
+        plugin_filename_results_list = [row.plugin_filename.lower() for row in cs_advanced.top_results(19)]
         Assert.is_sorted_descending(plugin_filename_results_list)


### PR DESCRIPTION
Only checking 19 random results for plugin icon rather than all results.
Only checking top 19 results for sorting (both ascending and descending) rather than all results.
Removed the step that chooses a random page of results as it was time consuming and I'm not sure what value it adds. This last change should be vetted by someone at Mozilla.
