### PR TITLE
Performance tweaks for test_that_only_browser_reports_have_browser_icon

### DIFF
--- a/pages/crash_stats_top_crashers_page.py
+++ b/pages/crash_stats_top_crashers_page.py
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import random
+
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
 
@@ -89,6 +91,13 @@ class CrashStatsTopCrashers(CrashStatsBasePage):
     def signature_items(self):
         return [self.SignatureItem(self.testsetup, i)
                     for i in self.selenium.find_elements(*self._signature_table_row_locator)]
+
+    def random_signature_items(self, count):
+        signature_items = self.signature_items
+        random_signature_items = []
+        for i in range(0, count):
+            random_signature_items.append(random.choice(signature_items))
+        return random_signature_items
 
     def click_first_signature(self):
         return self.signature_items[0].click()

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -14,6 +14,7 @@ class CrashStatsHomePage(CrashStatsBasePage):
         https://crash-stats.allizom.org/
     """
     _release_channels_locator = (By.CSS_SELECTOR, '.release_channel')
+    _last_release_channel_locator = (By.CSS_SELECTOR, '#release_channels .release_channel:last-child')
 
     def __init__(self, testsetup, product=None):
         '''
@@ -25,7 +26,9 @@ class CrashStatsHomePage(CrashStatsBasePage):
             self.selenium.get(self.base_url)
 
     def click_last_product_top_crashers_link(self):
-        return self.release_channels[-1].click_top_crasher()
+        return self.ReleaseChannels(
+            self.testsetup, self.selenium.find_element(*self._last_release_channel_locator)
+        ).click_top_crasher()
 
     @property
     def release_channels(self):

--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -200,7 +200,7 @@ class TestCrashReports:
         Assert.equal((type, days, os), (reports_page.current_filter_type,
                                         reports_page.current_days_filter,
                                         reports_page.current_os_filter))
-        signature_list_items = reports_page.signature_items
+        signature_list_items = reports_page.random_signature_items(19)
         Assert.true(len(signature_list_items) > 0, "Signature list items not found")
 
         for signature_item in signature_list_items:


### PR DESCRIPTION
@stephendonner's request 

Changed the test to check only 19 random signature items rather than all signature items.
Changed code to directly use the last release channel rather than creating all of them and then using the last one.

These tweaks do shave a few seconds off the run, but most of the time seems to be because of wait_for_ajax and numerous page loads. I'm not sure that anything can be done about either of those, unless there's a better way to define wait_for_ajax.
