### PR TITLE
Removed xfail from test_that_product_versions_are_ordered_correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.tmproj
 *.komodoproject
 *.idea
+results/*

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -20,17 +20,17 @@ class TestLayout:
         csp = CrashStatsHomePage(mozwebqa)
 
         product_list = ['Firefox',
-            'Thunderbird',
-            'Camino',
-            'SeaMonkey',
-            'Fennec',
-            'FennecAndroid',
-            'WebappRuntime',
-            'B2G']
+                        'Thunderbird',
+                        'Camino',
+                        'SeaMonkey',
+                        'Fennec',
+                        'FennecAndroid',
+                        'WebappRuntime',
+                        'B2G']
         products = csp.header.product_list
         Assert.equal(product_list, products)
 
-    @pytest.mark.xfail(reason='Bug 687841 - Versions in Navigation Bar appear in wrong order')
+    #@pytest.mark.xfail(reason='Bug 687841 - Versions in Navigation Bar appear in wrong order')
     @pytest.mark.nondestructive
     def test_that_product_versions_are_ordered_correctly(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)


### PR DESCRIPTION
Also added results/ to .gitignore and fixed a pep8 issue

@stephendonner to investigate https://bugzilla.mozilla.org/show_bug.cgi?id=687841 as it is not marked as fixed
