### PR TITLE
fixes for running on slow dev environments

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -71,4 +71,4 @@ class Page(object):
         self.selenium.back()
 
     def wait_for_ajax(self):
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: s.execute_script('return jQuery.active == 0'))
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: s.execute_script('return (typeof jQuery !== "undefined" && jQuery.active == 0)'))


### PR DESCRIPTION
Noticed a couple things, the second of which was definitely causing a lot of test failures:

1) timeout was hardcoded in a few places
2) jQuery may not exist at the time jQuery.active is called (which runs in a loop until timeout to see if the page is ready)
