### PR TITLE
remove camino from tests

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -20,7 +20,6 @@ class TestCrashReports:
     _expected_products = [
         'Firefox',
         'Thunderbird',
-        'Camino',
         'SeaMonkey',
         'Fennec',
         'FennecAndroid',
@@ -30,7 +29,6 @@ class TestCrashReports:
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
     def test_that_reports_form_has_same_product(self, mozwebqa, product):
-        if product == 'Camino': pytest.xfail(reason='bug 775254 - No data currently available for Camino')
         csp = CrashStatsHomePage(mozwebqa)
 
         csp.header.select_product(product)
@@ -42,7 +40,6 @@ class TestCrashReports:
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
     def test_that_current_version_selected_in_top_crashers_header(self, mozwebqa, product):
-        if product == 'Camino': pytest.xfail(reason='bug 775254 - No data currently available for Camino')
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)
 
@@ -80,7 +77,6 @@ class TestCrashReports:
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
     def test_that_products_page_links_work(self, mozwebqa, product):
-        if product == 'Camino': pytest.xfail(reason='bug 775254 - No data currently available for Camino')
         products_page = ProductsLinksPage(mozwebqa)
         #An extra check that products page is loaded
         Assert.equal(products_page.page_heading, 'Mozilla Products in Crash Reporter')

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -26,7 +26,6 @@ class TestLayout:
                         'Thunderbird',
                         'Fennec',
                         'FennecAndroid',
-                        'Camino',
                         'SeaMonkey',
                         'WebappRuntime',
                         'B2G']

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -17,7 +17,6 @@ class TestSearchForIdOrSignature:
 
     _expected_products = ['Firefox',
         'Thunderbird',
-        'Camino',
         'SeaMonkey',
         'Fennec',
         'FennecAndroid',

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -16,7 +16,6 @@ class TestSmokeTests:
 
     _expected_products = ['Firefox',
         'Thunderbird',
-        'Camino',
         'SeaMonkey',
         'Fennec',
         'FennecAndroid',


### PR DESCRIPTION
All of Camino's releases are expired, and we filter out invalid products now. Can we just remove this from tests?
