### PR TITLE
Fix for FX version comparison (bug 812679)

### DIFF
--- a/pages/version.py
+++ b/pages/version.py
@@ -105,7 +105,7 @@ class FirefoxVersion(Version):
         elif not self.prerelease and other.prerelease:
             return 1
         else:
-            prereleases = ('a', '(beta)', 'b', 'pre', 'esr')
+            prereleases = ('a', '(beta)', 'b', 'pre')
             prerelease_compare = cmp(prereleases.index(self.prerelease[0]),
                                      prereleases.index(other.prerelease[0]))
             if not prerelease_compare:


### PR DESCRIPTION
Versions were being compared improperly for ESR. ESR is not
considered a "pre-release" version, but the comparator for
FirefoxVersion was considering it one. Thus, 17.0 was a newer build
than 17.0esr. This change includes refactoring and adds support for
"postreleases", which are interim builds between numeric releases.
