### PR TITLE
Fix for soccoro.prod fails:

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -188,7 +188,7 @@ class TestCrashReports:
         """
         csp = CrashStatsHomePage(mozwebqa)
         top_crashers = csp.release_channels
-        tc_page = top_crashers[3].click_top_crasher()
+        tc_page = top_crashers[1].click_top_crasher()
 
         Assert.equal(tc_page.current_days_filter, '7')
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -69,6 +69,7 @@ class TestSearchForIdOrSignature:
             report = reports[index]
             Assert.equal(report.product, product)
             Assert.contains(report.version, version)
+
     @pytest.mark.xfail(reason='Disabled until bug 788601 is fixed')
     @pytest.mark.nondestructive
     def test_that_advanced_search_drilldown_results_are_correct(self, mozwebqa):


### PR DESCRIPTION
> > > tests.test_crash_reports.TestCrashReports.test_that_7_days_is_selected_default_for_nightlies
> > > tests.test_search.TestSearchForIdOrSignature.test_that_selecting_exact_version_doesnt_show_other_versions
> > > The first fail was caused by the modification of the nightly builds position on the home page.
> > > The second one was cause by lack of data on 19.0b1 build(which was released yesterday), but now it's populated.
