### PR TITLE
add MetroFirefox to product list

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -29,8 +29,9 @@ class TestLayout:
                         'FennecAndroid',
                         'SeaMonkey',
                         'WebappRuntime',
-                        'B2G'
-                        'WebappRuntimeMobile']
+                        'B2G',
+                        'WebappRuntimeMobile',
+                        'MetroFirefox']
         products = csp.header.product_list
         Assert.equal(product_list, products)
 


### PR DESCRIPTION
Adding <code>MetroFirefox</code> to the expected list of products, <code>product_list</code>.

This change will help crash-stats-django tests 
