### PR TITLE
update xfails for test_that_top_changers_is_highlighted_when_chosen

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -111,7 +111,9 @@ class TestCrashReports:
         cstc.click_filter_by('Plugin')
         Assert.greater(cstc.results_count, 0)
 
-    @pytest.mark.xfail(reason='Disabled until Bug 603561 is fixed')
+    @pytest.mark.xfail("'crash-stats-dev.allizom.org' in config.getvalue('base_url')", reason="Bug 603561 - Top Changers option isn't highlighted when chosen")
+    @pytest.mark.xfail("'crash-stats.allizom.org' in config.getvalue('base_url')", reason="Bug 603561 - Top Changers option isn't highlighted when chosen")
+    @pytest.mark.xfail("'crash-stats.mozilla.com' in config.getvalue('base_url')", reason="Bug 603561 - Top Changers option isn't highlighted when chosen")
     @pytest.mark.nondestructive
     def test_that_top_changers_is_highlighted_when_chosen(self, mozwebqa):
         """


### PR DESCRIPTION
The <code>test_that_top_changers_is_highlighted_when_chosen()</code> passes for the django builds but not the standard builds.

I apologize for the blatant pep8 line length violation - if it should be remedied I'm open to ideas on how to tame the beast.

![squirrel_sith_lightning](https://f.cloud.github.com/assets/63193/422443/44376ac0-ad27-11e2-8d7d-7e2445fe89e6.jpg)
