### PR TITLE
removed the wait_for_ajax()

### DIFF
--- a/pages/advanced_search_page.py
+++ b/pages/advanced_search_page.py
@@ -79,7 +79,6 @@ class CrashStatsAdvancedSearch(CrashStatsBasePage):
 
     def click_filter_reports(self):
         self.selenium.find_element(*self._filter_crash_reports_button).click()
-        self.wait_for_ajax()
 
     def click_first_signature(self):
         return self.results[0].click_signature()

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -28,7 +28,6 @@ class CrashStatsBasePage(Page):
 
     def click_server_status(self):
         self.selenium.find_element(*self._server_status_locator).click()
-        self.wait_for_ajax()
         from pages.status_page import CrashStatsStatus
         return CrashStatsStatus(self.testsetup)
 
@@ -146,7 +145,6 @@ class CrashStatsBasePage(Page):
             select.select_by_visible_text(report_name)
 
             if 'Top Crashers' == report_name:
-                self.wait_for_ajax()
                 from pages.crash_stats_top_crashers_page import CrashStatsTopCrashers
                 return CrashStatsTopCrashers(self.testsetup)
             elif 'Top Crashers by TopSite' == report_name:

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -49,6 +49,5 @@ class CrashStatsHomePage(CrashStatsBasePage):
 
         def click_top_crasher(self):
             self._root_element.find_element(*self._top_crashers_link_locator).click()
-            self.wait_for_ajax()
             from pages.crash_stats_top_crashers_page import CrashStatsTopCrashers
             return CrashStatsTopCrashers(self.testsetup)

--- a/pages/page.py
+++ b/pages/page.py
@@ -69,6 +69,3 @@ class Page(object):
 
     def return_to_previous_page(self):
         self.selenium.back()
-
-    def wait_for_ajax(self):
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: s.execute_script('return (typeof jQuery !== "undefined" && jQuery.active == 0)'))

--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -150,7 +150,6 @@ class TestCrashReports:
         # Because the frontpage is now largely Ajax driven,
         # we need to add this wait before proceeding with the
         # next step.
-        csp.wait_for_ajax()
         top_crashers = csp.release_channels
 
         for idx in range(len(top_crashers)):
@@ -200,7 +199,6 @@ class TestCrashReports:
         https://www.pivotaltracker.com/story/show/17099455
         """
         csp = CrashStatsHomePage(mozwebqa)
-        csp.wait_for_ajax()
         reports_page = csp.click_last_product_top_crashers_link()
         type, days, os = 'Browser', '7', 'Windows'
         Assert.equal(reports_page.current_filter_type, type)


### PR DESCRIPTION
This is both a curious and cautious pull request. I believe that we can safely remove <code>wait_for_ajax()</code> with only positive effects. I believe it is no longer needed.

I investigated <code>WebDriverWait(self.selenium, self.timeout).until(lambda s: s.execute_script('return (typeof jQuery !== "undefined" && jQuery.active == 0)'))</code> which was causing consistent errors due to timeouts.

I tested the removed <code>wait_for_ajax()</code> against both the <code>PHP</code> and <code>Django</code> apps.
The tests consistently all pass:
- dev
- stage
- prod
