### PR TITLE
Exploitable crash reports should not be displayed for not logged in users

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -61,6 +61,7 @@ class CrashStatsBasePage(Page):
         _versions_locator = (By.TAG_NAME, 'option')
 
         _advanced_search_locator = (By.LINK_TEXT, 'Advanced Search')
+        _exploitable_crash_report_locator = (By.CSS_SELECTOR, '#report_select option[value="/report/exploitability/"]')
 
         @property
         def current_product(self):
@@ -177,3 +178,13 @@ class CrashStatsBasePage(Page):
             self.selenium.find_element(*self._advanced_search_locator).click()
             from pages.advanced_search_page import CrashStatsAdvancedSearch
             return CrashStatsAdvancedSearch(self.testsetup)
+
+        @property
+        def report_list(self):
+            report_dropdown = self.selenium.find_element(*self._report_select_locator)
+            select = Select(report_dropdown)
+            return [opt.text for opt in select.options]
+
+        @property
+        def is_exploitable_crash_report_present(self):
+            return self.is_element_present(*self._exploitable_crash_report_locator)

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -65,3 +65,11 @@ class TestSmokeTests:
         path = '/invalidpath'
         csp.selenium.get(mozwebqa.base_url + path)
         Assert.contains('bug_file_loc=%s%s' % (mozwebqa.base_url, path), urllib.unquote(csp.link_to_bugzilla))
+
+    @pytest.mark.nondestructive
+    def test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users(self, mozwebqa):
+        """https://github.com/mozilla/Socorro-Tests/issues/214"""
+
+        csp = CrashStatsHomePage(mozwebqa)
+        Assert.true('Exploitable Crashes' not in csp.header.report_list)
+        Assert.false(csp.header.is_exploitable_crash_report_present)


### PR DESCRIPTION
Test for issue #214
