### PR TITLE
Xfailed test_the_product_releases_return_results['WebappRuntime'] due to...

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -129,6 +129,8 @@ class TestCrashReports:
         """
         https://www.pivotaltracker.com/story/show/17086667
         """
+        if product == 'WebappRuntime':
+            pytest.xfail(reason='Bug 918297 - [dev][stage]Nonexistent WebappRuntime version displayed on homepage')
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)
         # Because the frontpage is now largely Ajax driven,


### PR DESCRIPTION
... Bug 918297 - [dev][stage]Nonexistent WebappRuntime version displayed on homepage

https://bugzilla.mozilla.org/show_bug.cgi?id=918297
