### PR TITLE
Xfail test_that_advanced_search_drilldown_results_are_correct() because ...

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -70,6 +70,8 @@ class TestSearchForIdOrSignature:
             Assert.contains(report.version, version)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail('config.getvalue("base_url") == "https://crash-stats.allizom.org"',
+                       reason='Bug 968476 - [stage][regression] crash counts appear to be different in query/ tab-summary / tab-reports')
     def test_that_advanced_search_drilldown_results_are_correct(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         cs_advanced = csp.header.click_advanced_search()


### PR DESCRIPTION
...of Bug 968476 - [stage][regression] crash counts appear to be different in query/ tab-summary / tab-reports
