### PR TITLE
Add Continuous Integration section in readme to show Travis CI status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The following contributors have submitted pull requests to mozillians-tests:
 
 https://github.com/mozilla/Socorro-tests/contributors
 
+Continuous Integration
+----------------------
+[![Build Status](https://secure.travis-ci.org/mozilla/Socorro-Tests.png?branch=master)](http://travis-ci.org/mozilla/Socorro-Tests/)
+
 Getting involved as a contributor
 ---------------------------------
 


### PR DESCRIPTION
See the nice green button in the readme :D

https://github.com/bebef1987/Socorro-Tests/tree/add_readme#continuous-integration
