### PR TITLE
Xfail top_crashers_header

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -27,8 +27,6 @@ class TestCrashReports:
 
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
-    @xfail("'-dev' in config.getvalue('base_url')",
-           reason="Bug 962056 - [dev] Internal server error returned when selecting 'Crashes per User' report for any product")
     def test_that_reports_form_has_same_product(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
 
@@ -40,6 +38,7 @@ class TestCrashReports:
 
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
+    @xfail(reason="Bug 1013916 - [prod][stage]Top Crashers for B2G selects the wrong version and returns Page not found")
     def test_that_current_version_selected_in_top_crashers_header(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)


### PR DESCRIPTION
Bug 1013916 - [prod][stage]Top Crashers for B2G selects the wrong version and returns Page not found
