### PR TITLE
Unxfail the Bug 1010987 - Wrong order for the version in the drop-down menu

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -30,7 +30,6 @@ class TestLayout:
         Assert.equal(product_list, products)
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason = 'Bug 1010987 - [prod] Wrong order for the version in the drop-down menu')
     def test_that_product_versions_are_ordered_correctly(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
 


### PR DESCRIPTION
This no longer applies since the versions are no longer displayed in the list
