### PR TITLE
Fixes #291 - Wait for search results table to reflect selected columns

### DIFF
--- a/pages/super_search_page.py
+++ b/pages/super_search_page.py
@@ -129,16 +129,16 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
 
     class SearchResultHeader(Page):
 
-        _root_locator = (By.CSS_SELECTOR, '#reports-list thead')
-        _table_header_name_locator = (By.CSS_SELECTOR, 'th')
-
-        def __init__(self, testsetup):
-            Page.__init__(self, testsetup)
-            self._root_element = self.selenium.find_element(*self._root_locator)
+        _table_header_name_locator = (By.CSS_SELECTOR, '#reports-list thead th')
 
         @property
         def table_column_names(self):
-            return [table_column.text.lower() for table_column in self._root_element.find_elements(*self._table_header_name_locator)]
+            return [table_column.text.lower() for table_column in self.selenium.find_elements(*self._table_header_name_locator)]
+
+        def is_column_not_present(self, column_name):
+            WebDriverWait(self.selenium, self.timeout).until(
+                lambda s: column_name not in self.table_column_names, message='Column %s found in table header.' % column_name)
+            return True
 
     class Column(Page):
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -101,7 +101,7 @@ class TestSearchForIdOrSignature:
             if len(cs_super.columns) > 1:
                 cs_super.click_crash_reports_tab()
                 Assert.true(cs_super.are_search_results_found)
-                Assert.false(current_column in cs_super.search_results_table_header.table_column_names)
+                Assert.true(cs_super.search_results_table_header.is_column_not_present(current_column))
 
         Assert.true(cs_super.columns[0].column_name in cs_super.search_results_table_header.table_column_names)
 


### PR DESCRIPTION
Also address StaleElementException

This test was failing as per issue #291. I found that the problem was that after removing a column from the "Show columns:" list, and clicking the "Search" button, the removed column does appear in the results, but is later removed (must be some Javascript magic), so the test was failing when checking to see if the column was not there. I changed the code to wait for the column to be not present, and that seemed to fix the issue for me locally.

I also encountered a `StaleElementException` during my testing (see below), which I fixed in `table_column_names`.

Stack Trace of `StaleElementException`:

```
self = <tests.test_search.TestSearchForIdOrSignature instance at 0x112832d40>
mozwebqa = <pytest_mozwebqa.pytest_mozwebqa.TestSetup instance at 0x1128375a8>

@pytest.mark.nondestructive
def test_search_change_column(self, mozwebqa):
csp = CrashStatsHomePage(mozwebqa)
cs_super = csp.header.click_super_search()
cs_super.select_field('product')
cs_super.select_operator('has terms')

cs_super.click_search()
Assert.true(cs_super.are_search_results_found)
cs_super.click_more_options()

# Delete all columns except the last one
for column in cs_super.columns[:-1]:
cs_super.click_crash_reports_tab()
current_column = column.column_name
Assert.true(current_column in cs_super.search_results_table_header.table_column_names)

number_of_columns = len(cs_super.columns)
column.delete_column()
cs_super.wait_for_column_deleted(number_of_columns - 1)
Assert.false(cs_super.is_column_in_list(current_column))

cs_super.click_search()
if len(cs_super.columns) > 1:
cs_super.click_crash_reports_tab()
Assert.true(cs_super.are_search_results_found)
> Assert.false(current_column in cs_super.search_results_table_header.table_column_names)

tests/test_search.py:104:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pages.super_search_page.SearchResultHeader object at 0x10fdf4c50>

@property
def table_column_names(self):
> return [table_column.text.lower() for table_column in self._root_element.find_elements(*self._table_header_name_locator)]

pages/super_search_page.py:141:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <selenium.webdriver.remote.webelement.WebElement object at 0x10fdff890>

@property
def text(self):
"""Gets the text of the element."""
> return self._execute(Command.GET_ELEMENT_TEXT)['value']

../../.virtualenvs/Socorro-Tests/lib/python2.7/site-packages/selenium/webdriver/remote/webelement.py:61:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <selenium.webdriver.remote.webelement.WebElement object at 0x10fdff890>, command = 'getElementText'
params = {'id': u'{76772680-0c6d-1747-84c3-1b96444304fe}', 'sessionId': u'3e746dca-9e83-9244-889b-3c56354d53bb'}

def _execute(self, command, params=None):
"""Executes a command against the underlying HTML element.

Args:
command: The name of the command to _execute as a string.
params: A dictionary of named parameters to send with the command.

Returns:
The command's JSON response loaded into a dictionary object.
"""
if not params:
params = {}
params['id'] = self._id
> return self._parent.execute(command, params)

../../.virtualenvs/Socorro-Tests/lib/python2.7/site-packages/selenium/webdriver/remote/webelement.py:385:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <selenium.webdriver.firefox.webdriver.WebDriver object at 0x112899690>, driver_command = 'getElementText'
params = {'id': u'{76772680-0c6d-1747-84c3-1b96444304fe}', 'sessionId': u'3e746dca-9e83-9244-889b-3c56354d53bb'}

def execute(self, driver_command, params=None):
"""
Sends a command to be executed by a command.CommandExecutor.

:Args:
- driver_command: The name of the command to execute as a string.
- params: A dictionary of named parameters to send with the command.

:Returns:
The command's JSON response loaded into a dictionary object.
"""
if self.session_id is not None:
if not params:
params = {'sessionId': self.session_id}
elif 'sessionId' not in params:
params['sessionId'] = self.session_id

params = self._wrap_value(params)
response = self.command_executor.execute(driver_command, params)
if response:
> self.error_handler.check_response(response)

../../.virtualenvs/Socorro-Tests/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py:173:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <selenium.webdriver.remote.errorhandler.ErrorHandler object at 0x112899810>
response = {u'name': u'getElementText', u'sessionId': u'3e746dca-9e83-9244-889b-3c56354d53bb', u'status': 10, u'value': {u'messag...ponents/command-processor.js:548', u'lineNumber': 5, u'methodName': u'fxdriver.Timer.prototype.setTimeout/<.notify'}]}}

def check_response(self, response):
"""
Checks that a JSON response from the WebDriver does not have an error.

:Args:
- response - The JSON response from the WebDriver server as a dictionary
object.

:Raises: If the response contains an error message.
"""
status = response['status']
if status == ErrorCode.SUCCESS:
return
exception_class = ErrorInResponseException
if status in ErrorCode.NO_SUCH_ELEMENT:
exception_class = NoSuchElementException
elif status in ErrorCode.NO_SUCH_FRAME:
exception_class = NoSuchFrameException
elif status in ErrorCode.NO_SUCH_WINDOW:
exception_class = NoSuchWindowException
elif status in ErrorCode.STALE_ELEMENT_REFERENCE:
exception_class = StaleElementReferenceException
elif status in ErrorCode.ELEMENT_NOT_VISIBLE:
exception_class = ElementNotVisibleException
elif status in ErrorCode.INVALID_ELEMENT_STATE:
exception_class = InvalidElementStateException
elif status in ErrorCode.INVALID_SELECTOR \
or status in ErrorCode.INVALID_XPATH_SELECTOR \
or status in ErrorCode.INVALID_XPATH_SELECTOR_RETURN_TYPER:
exception_class = InvalidSelectorException
elif status in ErrorCode.ELEMENT_IS_NOT_SELECTABLE:
exception_class = ElementNotSelectableException
elif status in ErrorCode.INVALID_COOKIE_DOMAIN:
exception_class = WebDriverException
elif status in ErrorCode.UNABLE_TO_SET_COOKIE:
exception_class = WebDriverException
elif status in ErrorCode.TIMEOUT:
exception_class = TimeoutException
elif status in ErrorCode.SCRIPT_TIMEOUT:
exception_class = TimeoutException
elif status in ErrorCode.UNKNOWN_ERROR:
exception_class = WebDriverException
elif status in ErrorCode.UNEXPECTED_ALERT_OPEN:
exception_class = UnexpectedAlertPresentException
elif status in ErrorCode.NO_ALERT_OPEN:
exception_class = NoAlertPresentException
elif status in ErrorCode.IME_NOT_AVAILABLE:
exception_class = ImeNotAvailableException
elif status in ErrorCode.IME_ENGINE_ACTIVATION_FAILED:
exception_class = ImeActivationFailedException
elif status in ErrorCode.MOVE_TARGET_OUT_OF_BOUNDS:
exception_class = MoveTargetOutOfBoundsException
else:
exception_class = WebDriverException
value = response['value']
if isinstance(value, basestring):
if exception_class == ErrorInResponseException:
raise exception_class(response, value)
raise exception_class(value)
message = ''
if 'message' in value:
message = value['message']

screen = None
if 'screen' in value:
screen = value['screen']

stacktrace = None
if 'stackTrace' in value and value['stackTrace']:
stacktrace = []
try:
for frame in value['stackTrace']:
line = self._value_or_default(frame, 'lineNumber', '')
file = self._value_or_default(frame, 'fileName', '<anonymous>')
if line:
file = "%s:%s" % (file, line)
meth = self._value_or_default(frame, 'methodName', '<anonymous>')
if 'className' in frame:
meth = "%s.%s" % (frame['className'], meth)
msg = " at %s (%s)"
msg = msg % (meth, file)
stacktrace.append(msg)
except TypeError:
pass
if exception_class == ErrorInResponseException:
raise exception_class(response, message)
elif exception_class == UnexpectedAlertPresentException and 'alert' in value:
raise exception_class(message, screen, stacktrace, value['alert'].get('text'))
> raise exception_class(message, screen, stacktrace)
E StaleElementReferenceException: Message: Element not found in the cache - perhaps the page has changed since it was looked up
E Stacktrace:
E at fxdriver.cache.getElementAt (resource://fxdriver/modules/web-element-cache.js:8329:1)
E at Utils.getElementAt (file:///var/folders/sk/1kj23lvn46n7pvr7_xk074wm0000gn/T/tmp3xOGNC/extensions/fxdriver@googlecode.com/components/command-processor.js:7922:10)
E at WebElement.getElementText (file:///var/folders/sk/1kj23lvn46n7pvr7_xk074wm0000gn/T/tmp3xOGNC/extensions/fxdriver@googlecode.com/components/command-processor.js:11065:11)
E at DelayedCommand.prototype.executeInternal_/h (file:///var/folders/sk/1kj23lvn46n7pvr7_xk074wm0000gn/T/tmp3xOGNC/extensions/fxdriver@googlecode.com/components/command-processor.js:11635:16)
E at fxdriver.Timer.prototype.setTimeout/<.notify (file:///var/folders/sk/1kj23lvn46n7pvr7_xk074wm0000gn/T/tmp3xOGNC/extensions/fxdriver@googlecode.com/components/command-processor.js:548:5)

../../.virtualenvs/Socorro-Tests/lib/python2.7/site-packages/selenium/webdriver/remote/errorhandler.py:166: StaleElementReferenceException
```
