### PR TITLE
removing the need for a credentials.yaml file

### DIFF
--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 
 from pages.base_page import CrashStatsBasePage
 
@@ -16,8 +15,6 @@ class CrashStatsHomePage(CrashStatsBasePage):
     """
     _release_channels_locator = (By.CSS_SELECTOR, '.release_channel')
     _last_release_channel_locator = (By.CSS_SELECTOR, '#release_channels .release_channel:last-child')
-    _browserid_login_locator = (By.CSS_SELECTOR, 'div.login a.browserid-login')
-    _browserid_logout_locator = (By.CSS_SELECTOR, 'div.login a.browserid-logout')
 
     def __init__(self, testsetup, product=None):
         '''
@@ -27,29 +24,6 @@ class CrashStatsHomePage(CrashStatsBasePage):
 
         if product is None:
             self.selenium.get(self.base_url)
-
-    @property
-    def is_logged_out(self):
-        return self.selenium.find_element(*self._browserid_login_locator).is_displayed()
-
-    @property
-    def is_logged_in(self):
-        return self.selenium.find_element(*self._browserid_logout_locator).is_displayed()
-
-    def login(self, user='default'):
-        self.selenium.find_element(*self._browserid_login_locator).click()
-        credentials = self.testsetup.credentials[user]
-
-        from browserid import BrowserID
-        pop_up = BrowserID(self.selenium, self.timeout)
-        pop_up.sign_in(credentials['email'], credentials['password'])
-        WebDriverWait(self.selenium, self.timeout).until(
-            lambda s: self.is_logged_in, message='Could not log in within %s seconds.' % self.timeout)
-
-    def logout(self):
-        self.selenium.find_element(*self._browserid_logout_locator).click()
-        WebDriverWait(self.selenium, self.timeout).until(
-            lambda s: self.is_logged_out, message='Could not log out within %s seconds.' % self.timeout)
 
     def click_last_product_top_crashers_link(self):
         return self.ReleaseChannels(

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -51,14 +51,12 @@ class TestSmokeTests:
         Assert.true('Exploitable Crashes' not in csp.header.report_list)
         Assert.false(csp.header.is_exploitable_crash_report_present)
 
-    @pytest.mark.credentials
-    @pytest.mark.nondestructive
     def test_login_logout(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
-        Assert.true(csp.is_logged_out)
+        Assert.true(csp.footer.is_logged_out)
 
-        csp.login()
-        Assert.true(csp.is_logged_in)
+        csp.footer.login()
+        Assert.true(csp.footer.is_logged_in)
 
-        csp.logout()
-        Assert.true(csp.is_logged_out)
+        csp.footer.logout()
+        Assert.true(csp.footer.is_logged_out)


### PR DESCRIPTION
Our tests no longer have the need to log in using an account with elevated permissions.
* use personatestuser.org to create accounts with no special permissions attached
* refactored the page objects for better readability by creating `class Footer:`

Once the pr is merged we can delete the `socorro.yaml` credentials file.