### PR TITLE
configure travis to run flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,16 @@ python:
   - 2.7
 
 before_install:
-  - git submodule update --init --recursive
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 install:
-  - "pip install -Ur requirements.txt"
+  - "pip install flake8"
+  - "pip install -r requirements.txt"
 
-before_script:
-  - sh -e /etc/init.d/xvfb start
+before_script: "flake8 . --ignore=E501"
 
 script: py.test -n 4 -v -r fsxX --baseurl=https://crash-stats.allizom.org --driver=firefox --destructive -m "not credentials"
-
-env:
-  - DISPLAY=':99.0'
 
 notifications:
   email:


### PR DESCRIPTION
I did a bit of retooling to `.travis.yml`
* I refactored`.travis.yml`
* added `before_script:` and a `flake8` run

Many thanks to @davehunt's work -- his example `.travis.yml` is perfect -- https://github.com/mozilla/mozwebqa-examples/blob/master/.travis.yml