### PR TITLE
Mark Thunderbird and SeaMonkey tests as expected to fail

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -93,7 +93,13 @@ class TestCrashReports:
             Assert.equal(cstc.header.current_report, 'Top Changers')
 
     @pytest.mark.nondestructive
-    @pytest.mark.parametrize(('product'), _expected_products)
+    @pytest.mark.parametrize(('product'), [
+        'Firefox',
+        pytest.mark.xfail(reason='bug 1213200')('Thunderbird'),
+        pytest.mark.xfail(reason='bug 1213200')('SeaMonkey'),
+        'FennecAndroid',
+        'WebappRuntime',
+        'B2G'])
     def test_that_top_crashers_reports_links_work(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)
@@ -140,7 +146,13 @@ class TestCrashReports:
                            uuid_report.signature_in_table))
 
     @pytest.mark.nondestructive
-    @pytest.mark.parametrize(('product'), _expected_products)
+    @pytest.mark.parametrize(('product'), [
+        'Firefox',
+        pytest.mark.xfail(reason='bug 1213200')('Thunderbird'),
+        pytest.mark.xfail(reason='bug 1213200')('SeaMonkey'),
+        'FennecAndroid',
+        'WebappRuntime',
+        'B2G'])
     def test_the_product_releases_return_results(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)


### PR DESCRIPTION
See [bug 1213200](https://bugzilla.mozilla.org/show_bug.cgi?id=1213200) for details.

Pinging @m8ttyB for review.