### PR TITLE
Mark top crasher for plugins tests as expected to fail

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -74,6 +74,7 @@ class TestCrashReports:
         Assert.greater(cstc.results_count, 0)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason='bug 1213247')
     def test_that_top_crasher_filter_plugin_return_results(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         product = csp.header.current_product


### PR DESCRIPTION
See [bug 1213247](https://bugzilla.mozilla.org/show_bug.cgi?id=1213247) for details. Pinging @m8ttyB for review.