### PR TITLE
Top changers

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -92,6 +92,14 @@ class TestCrashReports:
             assert 'Top Changers' == cstc.header.current_report
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')",
+                       reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1185055")
+    def test_that_top_changers_data_is_available(self, mozwebqa):
+        csp = CrashStatsHomePage(mozwebqa)
+        cstc = csp.header.select_report('Top Changers')
+        assert 'Top changers currently unavailable' not in cstc.page_heading
+
+    @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), _expected_products)
     def test_that_top_crashers_reports_links_work(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
@@ -210,12 +218,3 @@ class TestCrashReports:
 
         cstc.click_filter_by('Plugin')
         assert 'error' not in cstc.page_heading
-
-    @pytest.mark.nondestructive
-    @pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')",
-                       reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1185055")
-    def test_that_top_changers_data_is_available(self, mozwebqa):
-        csp = CrashStatsHomePage(mozwebqa)
-        cstc = csp.header.select_report('Top Changers')
-
-        assert 'Top changers currently unavailable' not in cstc.page_heading

--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -82,6 +82,8 @@ class TestCrashReports:
         assert cstc.results_count > 0
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')",
+                       reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1185055")
     def test_that_top_changers_is_highlighted_when_chosen(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         for version in csp.header.current_versions:
@@ -210,6 +212,8 @@ class TestCrashReports:
         assert 'error' not in cstc.page_heading
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')",
+                       reason="https://bugzilla.mozilla.org/show_bug.cgi?id=1185055")
     def test_that_top_changers_data_is_available(self, mozwebqa):
         csp = CrashStatsHomePage(mozwebqa)
         cstc = csp.header.select_report('Top Changers')


### PR DESCRIPTION
Shortly, potentially within the next few days, the `top changer` reports will sunset. The update has landed on Stage, but not prod yet. Let's xfail the tests on stage, once the changes land on prod let's removed the tests.

See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1185055'>Bug 1185055</a>.

Issue #333 filed for test removal.