### PR TITLE
Wait for the crash stats home page to finish loading

### DIFF
--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait as Wait
 
 from pages.base_page import CrashStatsBasePage
 
@@ -13,6 +14,7 @@ class CrashStatsHomePage(CrashStatsBasePage):
         Page Object for Socorro
         https://crash-stats.allizom.org/
     """
+    _graph_locator = (By.ID, 'homepage-graph')
     _release_channels_locator = (By.CSS_SELECTOR, '.release_channel')
     _last_release_channel_locator = (By.CSS_SELECTOR, '#release_channels .release_channel:last-child')
 
@@ -24,6 +26,13 @@ class CrashStatsHomePage(CrashStatsBasePage):
 
         if product is None:
             self.selenium.get(self.base_url)
+        self.wait_for_page_to_load()
+
+    def wait_for_page_to_load(self):
+        Wait(self.selenium, self.timeout).until(
+            lambda s: 'loading' not in s.find_element(
+                *self._graph_locator).get_attribute('class'))
+        return self
 
     def click_last_product_top_crashers_link(self):
         return self.ReleaseChannels(

--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -86,14 +86,13 @@ class TestCrashReports:
     def test_that_top_crashers_reports_links_work(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)
-        top_crashers = csp.release_channels
 
-        for idx in range(len(top_crashers)):
-            top_crasher_name = top_crashers[idx].product_version_label
-            top_crasher_page = top_crashers[idx].click_top_crasher()
+        for i in range(len(csp.release_channels)):
+            top_crasher_name = csp.release_channels[i].product_version_label
+            top_crasher_page = csp.release_channels[i].click_top_crasher()
             assert top_crasher_name in top_crasher_page.page_heading
             top_crasher_page.return_to_previous_page()
-            top_crashers = csp.release_channels
+            csp.wait_for_page_to_load()
 
     @pytest.mark.nondestructive
     def test_top_crasher_reports_tab_has_uuid_report(self, mozwebqa):
@@ -125,17 +124,15 @@ class TestCrashReports:
     def test_the_product_releases_return_results(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
         csp.header.select_product(product)
-        top_crashers = csp.release_channels
 
-        for idx in range(len(top_crashers)):
-            top_crasher_page = top_crashers[idx].click_top_crasher()
+        for i in range(len(csp.release_channels)):
+            top_crasher_page = csp.release_channels[i].click_top_crasher()
             if top_crasher_page.no_results_text is not False:
                 assert 'No crashing signatures found for the period' in top_crasher_page.no_results_text
             else:
                 assert top_crasher_page.results_found, 'No results found'
-
             top_crasher_page.return_to_previous_page()
-            top_crashers = csp.release_channels
+            csp.wait_for_page_to_load()
 
     @pytest.mark.nondestructive
     def test_that_7_days_is_selected_default_for_nightlies(self, mozwebqa):


### PR DESCRIPTION
This addresses the current failures, most likely caused by Selenium clicking too soon.

Adhoc: http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/socorro.adhoc/43/