### PR TITLE
update bidpom

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ pytest==2.7.0
 pytest-mozwebqa
 requests==2.4.3
 selenium
--e git+https://github.com/mozilla/bidpom.git@master#egg=browserid
+bidpom


### PR DESCRIPTION
Fixes an issue where we were grabbing bidpom from GitHub which was causing us to pick up a newer version than we wanted. Socorro-Tests is not ready for bidpom 2.0 yet.