### PR TITLE
Fix intermittent failure of tests that use CrashReport.click_reports_tab

### DIFF
--- a/pages/crash_report_page.py
+++ b/pages/crash_report_page.py
@@ -13,7 +13,6 @@ class CrashReport(CrashStatsBasePage):
 
     _reports_tab_locator = (By.ID, 'reports')
     _results_count_locator = (By.CSS_SELECTOR, 'span.totalItems')
-    _reports_loading_locator = (By.CSS_SELECTOR, '#reports p.loading-placeholder')
     _reports_row_locator = (By.CSS_SELECTOR, '#reports-list tbody tr')
     _report_tab_button_locator = (By.CSS_SELECTOR, '#panels-nav .reports')
 
@@ -27,7 +26,7 @@ class CrashReport(CrashStatsBasePage):
 
     def click_reports_tab(self):
         self.selenium.find_element(*self._report_tab_button_locator).click()
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: not self.is_element_visible(None, *self._reports_loading_locator))
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: len(self.reports))
 
     class Report(CrashStatsBasePage):
 


### PR DESCRIPTION
As buildmaster I have noticed a couple of intermittents where it seems that the wait is not working when switching to the reports tab on the crash stats page. An example can be seen at [1].

When investigating it seemed that the current locator for the loading div is no longer valid - when running the code and inspecting the dom, an element with that locator never exists. I did find a new locator for the loading div, but the problem is we are doing a check for not visible, and that check can return True even before the div appears. My solution was to wait until there are actually reports displayed, rather than wait for the loader div to not be displayed.

@m8ttyB Can you please take a look and let me know what you think?

[1] https://webqa-ci.mozilla.com/view/Socorro/job/socorro.prod.saucelabs/700/HTML_Report/
