### PR TITLE
update test to compare page heading to page title

### DIFF
--- a/pages/crash_stats_per_day.py
+++ b/pages/crash_stats_per_day.py
@@ -13,14 +13,17 @@ from pages.base_page import CrashStatsBasePage
 
 class CrashStatsPerDay(CrashStatsBasePage):
 
-    _page_title = 'Crashes per Active Daily User for Firefox'
-
+    _page_heading_locator = (By.CSS_SELECTOR, '#mainbody h2:nth-child(2)')
     _product_select_locator = (By.ID, 'daily_search_version_form_products')
     _date_start_locator = (By.CSS_SELECTOR, '.daily_search_body .date[name="date_start"]')
     _generate_button_locator = (By.ID, 'daily_search_version_form_submit')
     _table_locator = (By.ID, 'crash_data')
     _row_table_locator = (By.CSS_SELECTOR, '#crash_data > tbody > tr')
     _last_row_date_locator = (By.CSS_SELECTOR, '#crash_data > tbody > tr > td:nth-child(1):not(:last):last')
+
+    @property
+    def _page_title(self):
+        return self.page_heading
 
     @property
     def product_select(self):

--- a/pages/page.py
+++ b/pages/page.py
@@ -32,7 +32,7 @@ class Page(object):
         if self._page_title:
             WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.title)
 
-        assert self.selenium.title == self._page_title, 'Title did not match expected'
+        assert self.selenium.title == self._page_title
         return True
 
     def get_url_current_page(self):

--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -31,8 +31,9 @@ class TestCrashReports:
         csp.header.select_product(product)
         assert product in csp.page_title
 
-        crash_adu = csp.header.select_report('Crashes per Day')
-        assert crash_adu.header.current_product == crash_adu.product_select
+        crash_per_day = csp.header.select_report('Crashes per Day')
+        crash_per_day.is_the_current_page
+        assert crash_per_day.header.current_product == crash_per_day.product_select
 
     @pytest.mark.nondestructive
     @pytest.mark.parametrize(('product'), [


### PR DESCRIPTION
Remedy for issue #349.
* update to PO to use page heading as the expected page title string
* update to the `test_that_reports_form_has_same_product()`; verify page title and heading.