### PR TITLE
xfail seamonkey, prod only

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -38,7 +38,8 @@ class TestCrashReports:
     @pytest.mark.parametrize(('product'), [
         'Firefox',
         'Thunderbird',
-        'SeaMonkey',
+        pytest.mark.xfail("'mozilla.com' in config.getvalue('base_url')",
+                          reason='bug 1249138')('SeaMonkey'),
         'FennecAndroid',
         pytest.mark.xfail("'mozilla.com' in config.getvalue('base_url')",
                           reason='bug 1248776')('WebappRuntime'),


### PR DESCRIPTION
Add an xfail for [bug 1249138](https://bugzilla.mozilla.org/show_bug.cgi?id=1249138).