### PR TITLE
xfail seamonkey

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -38,7 +38,7 @@ class TestCrashReports:
     @pytest.mark.parametrize(('product'), [
         'Firefox',
         'Thunderbird',
-        'SeaMonkey',
+        pytest.mark.xfail("'mozilla.com' in config.getvalue('base_url')", reason='bug 1253531')('SeaMonkey'),
         'FennecAndroid',
         'WebappRuntime',
         'B2G'])


### PR DESCRIPTION
Add xfail to `test_that_current_version_selected_in_top_crashers_header` for Seamonkey.

See [bug 1253531](https://bugzilla.mozilla.org/show_bug.cgi?id=1253531) for more details.

/cc @stephendonner 