### PR TITLE
Remove WebappRuntime*

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -14,7 +14,6 @@ class TestCrashReports:
         'Thunderbird',
         'SeaMonkey',
         'FennecAndroid',
-        'WebappRuntime',
         'B2G']
 
     @pytest.mark.nondestructive
@@ -23,7 +22,6 @@ class TestCrashReports:
         'Thunderbird',
         'SeaMonkey',
         'FennecAndroid',
-        'WebappRuntime',
         pytest.mark.xfail(reason='bug 1232440')('B2G')])
     def test_that_reports_form_has_same_product(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)
@@ -40,7 +38,6 @@ class TestCrashReports:
         'Thunderbird',
         pytest.mark.xfail("'mozilla.com' in config.getvalue('base_url')", reason='bug 1253531')('SeaMonkey'),
         'FennecAndroid',
-        'WebappRuntime',
         'B2G'])
     def test_that_current_version_selected_in_top_crashers_header(self, mozwebqa, product):
         csp = CrashStatsHomePage(mozwebqa)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -17,9 +17,7 @@ class TestLayout:
                         'Fennec',
                         'FennecAndroid',
                         'SeaMonkey',
-                        'WebappRuntime',
-                        'B2G',
-                        'WebappRuntimeMobile']
+                        'B2G']
         products = csp.header.product_list
 
         assert product_list == products, 'Expected products not in the product dropdown'

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -14,7 +14,6 @@ class TestSmokeTests:
                           'Thunderbird',
                           'SeaMonkey',
                           'FennecAndroid',
-                          'WebappRuntime',
                           'B2G']
 
     @pytest.mark.nondestructive


### PR DESCRIPTION
Following from https://bugzilla.mozilla.org/show_bug.cgi?id=1238129, peterbe has removed WebappRuntime* from both stage and prod; see below:

`12:23 PM <peterbe> I updated prod PG so that WebappRuntime and WebappRuntimeMobile will be gone as a drop-down option. 
12:23 PM <peterbe> We tested it this morning on stage. It’s gone from there now. 
12:24 PM <peterbe> I did it about 20 min ago, but there’s a 1h cache on this. `

So, while this currently passes on staging, it fails *right now* on prod, but should pass, according to @peterbe around 1pm PDT :-)

r? @m8ttyB?