### PR TITLE
add a webdriver wait

### DIFF
--- a/pages/crash_report_page.py
+++ b/pages/crash_report_page.py
@@ -15,6 +15,11 @@ class CrashReport(CrashStatsBasePage):
     _results_count_locator = (By.CSS_SELECTOR, 'span.totalItems')
     _reports_row_locator = (By.CSS_SELECTOR, '#reports-list tbody tr')
     _report_tab_button_locator = (By.CSS_SELECTOR, '#panels-nav .reports')
+    _summary_table_locator = (By.CSS_SELECTOR, '.content')
+
+    def __init__(self, base_url, selenium):
+        CrashStatsBasePage.__init__(self, base_url, selenium)
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: s.find_element(*self._summary_table_locator).is_displayed())
 
     @property
     def reports(self):


### PR DESCRIPTION
This is a bit convoluted, however `test_selecting_one_version_doesnt_show_other_versions` has been intermittently failing (and passing). It turns out the test was passing for the wrong reason. 

The test verifies that 20 reports signatures are for the Firefox product. The test randomly looks at 20 report items. Due to the nature of crashes, the majority of them are for Firefox. Due the high probability that the test would select a report item that was Firefox even though other products were incorrectly in the report list, the test would pass.

There is a timing issue where the page returns too quickly and the `click_reports_tab()` method is being called too soon.

        crash_report_page = report_list.click_first_signature()
        crash_report_page.click_reports_tab()

I've run the test several times and the WebdriverWait appears to allow the page to load correctly before clicking through to the reports tab.