### PR TITLE
improve non-priveledged account tests

### DIFF
--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -61,8 +61,6 @@ class CrashStatsBasePage(Page):
         _current_versions_locator = (By.CSS_SELECTOR, 'optgroup:nth-of-type(2) option')
         _versions_locator = (By.TAG_NAME, 'option')
         _loader_locator = (By.CLASS_NAME, 'loader')
-
-        _exploitable_crash_report_locator = (By.CSS_SELECTOR, '#report_select option[value="/report/exploitability/"]')
         _super_search_locator = (By.LINK_TEXT, 'Super Search')
 
         @property
@@ -172,10 +170,6 @@ class CrashStatsBasePage(Page):
             report_dropdown = self.selenium.find_element(*self._report_select_locator)
             select = Select(report_dropdown)
             return [opt.text for opt in select.options]
-
-        @property
-        def is_exploitable_crash_report_present(self):
-            return self.is_element_present(*self._exploitable_crash_report_locator)
 
         def click_super_search(self):
             self.selenium.find_element(*self._super_search_locator).click()

--- a/tests/test_smoke_tests.py
+++ b/tests/test_smoke_tests.py
@@ -15,6 +15,7 @@ class TestSmokeTests:
                           'SeaMonkey',
                           'FennecAndroid',
                           'B2G']
+    _exploitability_url = '/exploitability/?product=Firefox'
 
     @pytest.mark.nondestructive
     def test_that_bugzilla_link_contain_current_site(self, base_url, selenium):
@@ -27,16 +28,16 @@ class TestSmokeTests:
     @pytest.mark.nondestructive
     def test_that_exploitable_crash_report_not_displayed_for_not_logged_in_users(self, base_url, selenium):
         csp = CrashStatsHomePage(base_url, selenium)
-
         assert 'Exploitable Crashes' not in csp.header.report_list
-        assert csp.header.is_exploitable_crash_report_present is not True
+        csp.selenium.get(base_url + self._exploitability_url)
+        assert 'Login Required' in csp.page_heading
 
-    def test_login_logout(self, base_url, selenium):
+    def test_non_privileged__accounts_cannot_view_exploitable_crash_reports(self, base_url, selenium):
         csp = CrashStatsHomePage(base_url, selenium)
-        assert csp.footer.is_logged_out
-
         csp.footer.login()
         assert csp.footer.is_logged_in
-
+        assert 'Exploitable Crashes' not in csp.header.report_list
+        csp.selenium.get(base_url + self._exploitability_url)
+        assert 'Insufficient Privileges' in csp.page_heading
         csp.footer.logout()
         assert csp.footer.is_logged_out


### PR DESCRIPTION
I was investigating an intermittent failure for `test_login_logout` and decided to make the test more deterministic. It's unlikely this will remedy the intermittent failure but does improve the tests substantially. 

This change-set improves our tests to better insure escalation of account privileges doesn't occur.