### PR TITLE
remove Fennec product - it has aged out

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -15,7 +15,6 @@ class TestLayout:
         csp = CrashStatsHomePage(selenium, base_url).open()
         product_list = ['Firefox',
                         'Thunderbird',
-                        'Fennec',
                         'FennecAndroid',
                         'SeaMonkey']
         products = csp.header.product_list


### PR DESCRIPTION
The march continues. Fennec has aged out and is no longer an expect product.
* Remove `Fennec` from the layout tests.