### PR TITLE
fix POM and cleanup effected tests

### DIFF
--- a/pages/super_search_page.py
+++ b/pages/super_search_page.py
@@ -15,15 +15,15 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
     _page_title = 'Search - Mozilla Crash Reports'
 
     # Search parameters section
-    _field_text_locator = (By.CSS_SELECTOR, 'fieldset[id = "%s"] > div:nth-child(2) span')
-    _operator_text_locator = (By.CSS_SELECTOR, 'fieldset[id = "%s"] > div:nth-child(4) span')
+    _field_text_locator = (By.CSS_SELECTOR, 'fieldset[id="%s"] > div:nth-child(2) span')
+    _operator_text_locator = (By.CSS_SELECTOR, 'fieldset[id="%s"] > div:nth-child(4) span')
+    _operator_field_locator = (By.CSS_SELECTOR, 'fieldset[id="%s"] .select2-container.operator')
     _match_select_locator = (By.CSS_SELECTOR, 'fieldset[id="%s"] .select2-input')
     _match_text_locator = (By.CSS_SELECTOR, 'fieldset[id="%s"] > div:nth-child(6) div')
     _search_button_locator = (By.ID, 'search-button')
     _new_line_locator = (By.CSS_SELECTOR, '.new-line')
-    _operator_test_locator = (By.CSS_SELECTOR, 'li[class*="highlighted"] > div')
+    _highlighted_text_locator = (By.CSS_SELECTOR, 'li[class*="highlighted"] > div')
     _input_locator = (By.CSS_SELECTOR, '#s2id_autogen6')
-    _second_input_locator = (By.CSS_SELECTOR, '#s2id_autogen8')
 
     # More options section
     _more_options_locator = (By.CSS_SELECTOR, '.options h4')
@@ -47,16 +47,17 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
 
     def select_field(self, field):
         self.find_element(*self._input_locator).send_keys(field)
-        self.find_element(*self._operator_test_locator).click()
+        self.find_element(*self._highlighted_text_locator).click()
 
-    def select_operator(self, operator):
-        self.find_element(*self._second_input_locator).send_keys(operator)
-        self.find_element(*self._operator_test_locator).click()
+    def select_operator(self, line_id, operator):
+        input_locator = (self._operator_field_locator[0], self._operator_field_locator[1] % line_id)
+        self.find_element(*input_locator).send_keys(operator)
+        self.find_element(*self._highlighted_text_locator).click()
 
     def select_match(self, line_id, match):
         _match_locator = (self._match_select_locator[0], self._match_select_locator[1] % line_id)
         self.find_element(*_match_locator).send_keys(match)
-        self.find_element(*self._operator_test_locator).click()
+        self.find_element(*self._highlighted_text_locator).click()
 
     def field(self, line_id):
         return self.find_element(self._field_text_locator[0], self._field_text_locator[1] % line_id).text

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -5,7 +5,6 @@
 import pytest
 
 from pages.home_page import CrashStatsHomePage
-from pages.super_search_page import CrashStatsSuperSearch
 
 
 class TestLayout:
@@ -32,8 +31,10 @@ class TestSuperSearchLayout:
 
     @pytest.mark.nondestructive
     def test_default_fields_for_firefox(self, base_url, selenium):
-        selenium.get('{base_url}/search/?product=Firefox'.format(base_url=base_url))
-        cs_super = CrashStatsSuperSearch(selenium, base_url).wait_for_page_to_load()
+        csp = CrashStatsHomePage(selenium, base_url).open()
+        cs_super = csp.header.click_super_search()
+        # advanced search defaults to the terms below, verify that these are
+        # present
         assert 'product' == cs_super.field('0')
         assert 'has terms' == cs_super.operator('0')
         assert 'Firefox' == cs_super.match('0')
@@ -42,11 +43,9 @@ class TestSuperSearchLayout:
     def test_search_change_column(self, base_url, selenium):
         csp = CrashStatsHomePage(selenium, base_url).open()
         cs_super = csp.header.click_super_search()
-        cs_super.select_field('product')
-        cs_super.select_operator('has terms')
-
         cs_super.click_search()
         assert cs_super.are_search_results_found
+
         cs_super.click_more_options()
 
         # Delete all columns except the last one
@@ -66,15 +65,19 @@ class TestSuperSearchLayout:
                 assert cs_super.are_search_results_found
                 assert cs_super.search_results_table_header.is_column_not_present(current_column)
 
+        # advanced search defaults to the terms below, verify that these have
+        # persisted
+        assert 'product' == cs_super.field('0')
+        assert 'has terms' == cs_super.operator('0')
+        assert 'Firefox' == cs_super.match('0')
         assert cs_super.columns[0].column_name in cs_super.search_results_table_header.table_column_names
 
     @pytest.mark.nondestructive
     def test_search_change_facet(self, base_url, selenium):
         csp = CrashStatsHomePage(selenium, base_url).open()
         cs_super = csp.header.click_super_search()
-        cs_super.select_field('product')
-        cs_super.select_operator('has terms')
         cs_super.click_search()
+
         assert cs_super.facet in cs_super.results_facet.lower()
 
         cs_super.click_more_options()


### PR DESCRIPTION
We had one failing test on stage -- `test_search_for_unrealistic_data` -- that was due to a timing issue. The original test was authored to directly visit a url vs navigating to the page under test. I've taken the liberty of updating similar search tests that use this POM.

I've updated the test to navigate to the search page. I've also updated the locators to more explicitly identify which field to enter the search terms into.

* updated testcase(s) to explicitly navigate to the search page
* provide locators that are more explicit
* rename locators to be more explicit
* general test cleanup as well as explicit assertions