### PR TITLE
xfail product check

### DIFF
--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -10,6 +10,7 @@ from pages.home_page import CrashStatsHomePage
 class TestLayout:
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Fennec shouldn't be an option - bug 1292594")
     def test_that_products_are_sorted_correctly(self, base_url, selenium):
         csp = CrashStatsHomePage(selenium, base_url).open()
         product_list = ['Firefox',


### PR DESCRIPTION
The FTP scraper ran and added Fennec to the product list. [Bug 1292594](https://bugzilla.mozilla.org/show_bug.cgi?id=1292594#c8) has been reopened.

In the meantime, xfailing `test_that_products_are_sorted_correctly`.