### PR TITLE
xfail thunderbird test

### DIFF
--- a/tests/test_crash_reports.py
+++ b/tests/test_crash_reports.py
@@ -118,7 +118,11 @@ class TestCrashReports:
             'Signature in body did not match the signature in the '
 
     @pytest.mark.nondestructive
-    @pytest.mark.parametrize(('product'), _expected_products)
+    @pytest.mark.parametrize(('product'), [
+        'Firefox',
+        pytest.mark.xfail("'allizom.org' in config.getvalue('base_url')", reason='bug 1299916')('Thunderbird'),
+        'SeaMonkey',
+        'FennecAndroid'])
     def test_the_product_releases_return_results(self, base_url, selenium, product):
         csp = CrashStatsHomePage(selenium, base_url).open()
         csp.header.select_product(product)


### PR DESCRIPTION
The test flagged a failure on stage due to the messaging changing when no crashes are found. I'd like to add an xfail until we know what the expected behavior is:
* Is the lack of the old error message a regression?
* Re-address the topic of keeping stage data in roughly the same shape as prod.