### PR TITLE
add additional waits that follow the application's workflow.

### DIFF
--- a/pages/super_search_page.py
+++ b/pages/super_search_page.py
@@ -81,19 +81,24 @@ class CrashStatsSuperSearch(CrashStatsBasePage):
     def select_facet(self, line_id, field):
         input_locator = (self._facet_field_locator[0], self._facet_field_locator[1] % line_id)
         self.wait.until(lambda s: self.is_element_present(*input_locator))
-        self.find_element(*input_locator).send_keys(field)
-        self.find_element(*input_locator).send_keys(Keys.RETURN)
+        facet_field = self.find_element(*input_locator)
+        facet_field.send_keys(field)
+        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        facet_field.send_keys(Keys.RETURN)
 
     def select_operator(self, line_id, operator):
         input_locator = (self._operator_field_locator[0], self._operator_field_locator[1] % line_id)
         self.wait.until(lambda s: self.is_element_present(*input_locator))
-        self.find_element(*input_locator).send_keys(operator)
-        self.find_element(*self._highlighted_text_locator).click()
+        operator_field = self.find_element(*input_locator)
+        operator_field.send_keys(operator)
+        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
+        operator_field.send_keys(Keys.RETURN)
 
     def select_match(self, line_id, match):
         input_locator = (self._match_field_locator[0], self._match_field_locator[1] % line_id)
         self.wait.until(lambda s: self.is_element_present(*input_locator))
         self.find_element(*input_locator).send_keys(match)
+        self.wait.until(lambda s: self.is_element_present(*self._highlighted_text_locator))
         self.find_element(*self._highlighted_text_locator).click()
 
     def field(self, line_id):


### PR DESCRIPTION
This should add a bit more stability to the search tests as well as more correctly capture the expected usecase flow a user experiences that the current test cases touch.
* Form fields, once typed in should show a highlighted list of suggestion (future test will verify the suggestions).
* From fields should be able to receive clicks and a keyboard `return`

There are still some sporadic failures due to waits timing out. I'm narrowing in on the causes, the causes may be due to some intermittent behavior on crash-stats or simply some additional waits that are focused on waiting for background network activity to complete.

http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/mbrandt.socorro.prod.adhoc/7/

/cc @peterbe, @stephendonner, and @rbillings 